### PR TITLE
Typo Fix for "sfn"

### DIFF
--- a/content/module-9/step-4/index.en.md
+++ b/content/module-9/step-4/index.en.md
@@ -38,8 +38,8 @@ First, we'll review the individual code snippets that define the Synchronous Exp
 This AWS CDK code defines a simple state machine with a `pass` state. Review this code now.
 
 ```bash
-const startState = new sfn.Pass(this, 'PassState', {
-    result: {value:"Hello!"},
+const startState = new stepfunctions.Pass(this, 'PassState', {
+    result: { value: 'Hello back to you!' },
 })
 
 const stateMachine = new stepfunctions.StateMachine(this, 'MyStateMachine', {
@@ -77,7 +77,7 @@ export class StepfunctionsRestApiStack extends cdk.Stack {
       super(app, id);
 
       const startState = new stepfunctions.Pass(this, 'PassState', {
-          result: {value:"Hello back to you!"},
+          result: { value:'Hello back to you!' },
       })
 
       const stateMachine = new stepfunctions.StateMachine(this, 'CDKStateMachine', {


### PR DESCRIPTION
It looks like at some point there was a switch to importing * as
`stepfunctions` rather than `sfn`, but one line was not updated here.
This also updates some formatting to keep things all consistently using
the same quote-syntax